### PR TITLE
Init from toml fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # CHANGELOG
 
+## 0.1.0
+- Added new `init_from_toml` macro to allow initializing the app from a toml file
+    - `init_from_toml!` macro will read the toml file and initialize the app with the values
+- Deprecated `init_from_toml` function
+    - `init_from_toml` function is deprecated and will be removed in the next major release
+
 ## 0.0.10
 - Added auto version option to hrlp print version using `--version` or `-v`
 ## 0.0.9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fli"
 description = "The commander.js like CLI Parser for rust"
-version = "0.0.10"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/codad5/fli"

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ For stable changes check the [CHANGELOG.md](https://github.com/codad5/fli/blob/m
 For unstable changes check the [CHANGELOG.md](https://github.com/codad5/fli/blob/dev/CHANGELOG.md) file
 
 ```rust
-use fli::Fli;
+use fli::{Fli, init_from_toml};
 
 fn main(){
-    let mut app : Fli = Fli::init_from_toml();
+    let mut app : Fli = init_from_toml!(); // using the toml file
     app.option("-n --name, <>", "Name to call you", |x : &Fli| {});
     app.option("-g --greet", "greeting", |x : &Fli| {
         match x.get_values("name".to_owned() /* passing (--name, -n or n) would work*/){
@@ -58,7 +58,7 @@ fn main(){
 
 ```rust
 fn main(){
-    let mut app = Fli::init_from_toml(); // to init from your cargo.toml file
+    let mut app = init_from_toml!(); // to init from your cargo.toml file
 }
 
 ```
@@ -67,6 +67,7 @@ fn main(){
 ```rust
 fn main(){
     let mut app = Fli::init("app-name", "an app description");
+    app.set_version("0.0.1");
 }
 ```
 
@@ -75,7 +76,7 @@ fn main(){
 
 ```rust
 fn main(){
-    let mut app = Fli::init_from_toml();
+    let mut app = init_from_toml!();
     app.option("-g --greet", "to make a greeting", greet);
     app.option("-n --name, <>", "to set your name", |x|{});
 }
@@ -103,7 +104,7 @@ fn main(){
 You can also add a new command set using the command method
 ```rust
 fn main(){
-    let mut app = Fli::init_from_toml();
+    let mut app = init_from_toml!();
     app.command("greet", "An app that respects")
     .default(greet)
     .allow_inital_no_param_values(false)
@@ -128,7 +129,7 @@ use fli::Fli;
 
 fn main(){
     //  doing it procedual way
-    let mut app = Fli::init_from_toml();
+    let mut app = init_from_toml!();
     let moveCommand = app.command("move", "move files");
     // the [...] means accept optional multiple
     moveCommand.option("-p --path, <...>", "path to files to be moved", move_file);

--- a/sample/Cargo.lock
+++ b/sample/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "fli"
-version = "0.0.10"
+version = "0.1.0"
 dependencies = [
  "colored",
 ]

--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "sample"
+description = "A sample project to demonstrate how to use fli"
 version = "0.1.0"
 edition = "2021"
 

--- a/sample/src/main.rs
+++ b/sample/src/main.rs
@@ -1,4 +1,4 @@
-use fli::Fli;
+use fli::{init_fli_from_toml, Fli};
 
 
 
@@ -16,7 +16,7 @@ use fli::Fli;
 
 
 fn main(){
-    let mut app : Fli = Fli::init_from_toml();
+    let mut app : Fli = init_fli_from_toml!();
     app.allow_inital_no_param_values(false);
 
     let mut calc_app = app.command("calc", "perform basic 2 numeric calculation");

--- a/src/fli.rs
+++ b/src/fli.rs
@@ -62,6 +62,7 @@ impl Fli {
     /// 
     /// # Returns
     /// * `Fli` - The Fli struct
+    #[deprecated]
     pub fn init_from_toml() -> Self {
         let name = env!("CARGO_PKG_NAME");
         let description = env!("CARGO_PKG_DESCRIPTION");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 
 #[cfg(not(doctest))]
 pub mod fli;
+pub mod macros;
 
 pub use fli::Fli;
 use colored::Colorize;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,12 @@
+#[macro_export]
+macro_rules! init_fli_from_toml {
+    () => {{
+        let mut app = $crate::Fli::init(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_DESCRIPTION")
+        );
+        app.set_version(env!("CARGO_PKG_VERSION"));
+        app
+    }};
+}
+


### PR DESCRIPTION
# CHANGELOG

## 0.1.0
- Added new `init_from_toml` macro to allow initializing the app from a toml file
    - `init_from_toml!` macro will read the toml file and initialize the app with the values
- Deprecated `init_from_toml` function
    - `init_from_toml` function is deprecated and will be removed in the next major release